### PR TITLE
feat: add MinIO server for file storage purposes (#2)

### DIFF
--- a/.ci/secrets/minio-root-password
+++ b/.ci/secrets/minio-root-password
@@ -1,0 +1,1 @@
+minio-root-password

--- a/.ci/secrets/minio-varfish-password
+++ b/.ci/secrets/minio-varfish-password
@@ -1,0 +1,1 @@
+minio-varfish-password

--- a/.env.ci
+++ b/.env.ci
@@ -47,6 +47,18 @@
 # Version of the redis image to use.
 # image_redis_version=6
 
+# Name of the Minio image to use.
+# image_minio_name=quay.io/minio/minio
+
+# Version of the Minio image to use.
+# image_minio_version=latest
+
+# Name of the "mc" (Minio client) image to use.
+# image_mc_name=minio/mc
+
+# Version of the "mc" (Minio client) image to use.
+# image_mc_version=latest
+
 # -- General Container Configuration -----------------------------------------
 
 # Base directory for volumes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           mkdir -p .ci/volumes/postgres/data
           mkdir -p .ci/volumes/redis/data
+          mkdir -p .ci/volumes/minio/data
           mkdir -p .ci/volumes/varfish-static/data
 
       - name: Bring up and shut down services

--- a/README.md
+++ b/README.md
@@ -2,6 +2,78 @@
 
 This repository contains the [Docker Compose](https://docs.docker.com/compose/) configuration for the [VarFish Server](https://github.com/bihealth/varfish-server).
 
+## Service Information
+
+This section describes the services that are started with this Docker Compose.
+
+### MinIO
+
+[MinIO](https://min.io/) is an S3-compatible object storage server.
+The `docker-compose.yml` file will spin up a (single) container with the name `minio` that is used as (a) an internal file storage for VarFish and (b) can be used to upload data into that is then imported by VarFish.
+
+Further, a container `minio-client` is started that you can attach as shown below.
+On startup, the `minio-client` container will automatically create a user `varfish` using the secret `minio-varfish-password` as the password.
+Further, it will create a bucket `varfish-server` and give read/write access to the bucket for the user `varfish`.
+This is the account that VarFish will use to store data in the bucket.
+
+```
+$ docker-compose exec -it minio-client bash -i
+```
+
+The alias `minio` is pre-configured to point to the MinIO server.
+For example
+
+```
+host $ docker exec -it minio-client bash -i
+[root@minio-client /]# mc ls minio
+[2023-06-20 15:09:08 UTC]     0B varfish-server/
+[root@minio-client /]# mc admin user ls minio
+enabled    varfish               varfish-bucket-po...
+[root@minio-client /]# mc admin user info minio  varfish
+AccessKey: varfish
+Status: enabled
+PolicyName: varfish-bucket-policy
+MemberOf: []
+```
+
+You can create new users, e.g., for uploading data, as follows.
+Note that `the-user` corresponds to an S3 access key while `THE_PASSWORD` corresponds to an S3 secret key.
+
+```
+host $ docker exec -it minio-client bash -i
+[root@minio-client /]# mc mb minio/the-bucket
+Bucket created successfully `minio/the-bucket`.
+[root@minio-client /]# mc admin user add minio the-user THE_PASSWORD
+Added user `the-user` successfully.
+[root@minio-client /]# sed -e "s/__BUCKET__/the-bucket/g" \
+    /opt/minio-utils/bucket-user-policy.json.tpl \
+    > /tmp/the-user-bucket-policy.json
+[root@minio-client /]# cat /tmp/the-user-bucket-policy.json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject"
+        ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::the-bucket/*", "arn:aws:s3:::the-bucket"
+      ],
+      "Sid": "BucketAccessForUser"
+    }
+  ]
+}
+[root@minio-client /]# mc admin policy create minio the-user-bucket-policy /tmp/the-user-bucket-policy.json
+Created policy `the-user-bucket-policy` successfully.
+[root@minio-client /]# mc admin policy attach minio the-user-bucket-policy --user the-user
+Attached Policies: [the-user-bucket-policy]
+To User: the-user
+```
+
 ## Developer Info
 
 ### Managing GitHub Project with Terraform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
 
   traefik:
     <<: *service_default
+    container_name: traefik
+    hostname: traefik
     image: ${image_traefik_name:-traefik}:${image_traefik_version:-2.10}
     # Expose the default HTTP and HTTPS ports.
     ports:
@@ -62,6 +64,8 @@ services:
 
   mehari:
     <<: *service_varfish_default
+    container_name: mehari
+    hostname: mehari
     image: "${image_base:-ghcr.io/bihealth}/${image_mehari_name:-mehari}:\
       ${image_mehari_version:-0.5}"
 
@@ -72,6 +76,8 @@ services:
 
   viguno:
     <<: *service_varfish_default
+    container_name: viguno
+    hostname: viguno
     image: "${image_base:-ghcr.io/bihealth}/${image_viguno_name:-viguno}:\
       ${image_viguno_version:-0.1}"
 
@@ -81,6 +87,8 @@ services:
 
   annonars:
     <<: *service_varfish_default
+    container_name: annonars
+    hostname: annonars
     image: "${image_base:-ghcr.io/bihealth}/${image_annonars_name:-annona-rs}:\
       ${image_annonars_version:-0.12.4}"
 
@@ -91,6 +99,8 @@ services:
 
   postgres:
     <<: *service_default
+    container_name: postgres
+    hostname: postgres
     image: ${image_postgres_name:-postgres}:${image_postgres_version:-12}
     environment:
       POSTGRES_USER: varfish
@@ -110,19 +120,92 @@ services:
 
   redis:
     <<: *service_default
+    container_name: redis
+    hostname: redis
     image: ${image_redis_name:-redis}:${image_redis_version:-6}
     volumes:
       - type: bind
         source: ${volumes_basedir:-.}/redis/data
         target: /data
 
+  # -- Minio (Server) --------------------------------------------------------
+  #
+  # This runs the Minio that is for the internal usage by the VarFish server
+  # only!  It is not exposed to the outside world.
+  #
+  # We configure Minio in standalone mode.  Redundancy of storage must be
+  # ensured using RAID or similar (ZFS/BTRFS).
+
+  minio:
+    <<: *service_default
+    container_name: minio
+    hostname: minio
+    image: "${image_minio_name:-quay.io/minio/minio}:\
+      ${image_minio_version:-latest}"
+    command:
+      - server
+      - /data
+      - --console-address
+      - ":9001"
+    environment:
+      # The administrator credentials are "minioadmin" with the password as
+      # configured in the secret "minio-root-password".
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD_FILE: /run/secrets/minio-root-password
+    secrets:
+      - minio-root-password
+    # Uncomment the following two lines (reminder: "HOST:CONTAINER") to
+    # enable access to the console from the host.
+    ports:
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - type: bind
+        source: ${volumes_basedir:-.}/minio/data
+        target: /data
+
+  # -- Minio (Client) --------------------------------------------------------
+  #
+  # We will only run "sleep" here and pre-configure the credentials with the
+  # "minio" server.
+
+  minio-client:
+    <<: *service_default
+    container_name: minio-client
+    hostname: minio-client
+    depends_on:
+      - minio  # start after the server
+    image: "${image_mc_name:-quay.io/minio/mc}:\
+      ${image_mc_version:-latest}"
+    # Run with custom entrypoint that sets the alias "minio" with admin
+    # credentials, ensures that the "varfish" user and "varfish-server"
+    # buckets are created, and then sleeps forever.
+    entrypoint: /opt/minio-utils/entrypoint-override.sh
+    secrets:
+      - minio-root-password
+      - minio-varfish-password
+    volumes:
+      - type: bind
+        source: ./utils/minio-utils
+        target: /opt/minio-utils
+        read_only: true
 
 # == Secrets ================================================================
 
 secrets:
-  # The database password is configured via environment variable DB_PASSWORD.
+  # The PostgreSQL database password.
   db-password:
     file: ${secrets_basedir:-./secrets}/db-password
+  # The secrets for the root (=minioadmin) user on the MinIO server.
+  minio-root-password:
+    file: ${secrets_basedir:-./secrets}/minio-root-password
+  # The secrets for the varfish user on the MinIO server.
+  minio-varfish-password:
+    file: ${secrets_basedir:-./secrets}/minio-varfish-password
 
 
 # == Networks ================================================================

--- a/utils/minio-utils/bucket-user-policy.json.tpl
+++ b/utils/minio-utils/bucket-user-policy.json.tpl
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject"
+        ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::__BUCKET__/*", "arn:aws:s3:::__BUCKET__"
+      ],
+      "Sid": "BucketAccessForUser"
+    }
+  ]
+}

--- a/utils/minio-utils/entrypoint-override.sh
+++ b/utils/minio-utils/entrypoint-override.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/bash
+
+set -x
+set -euo pipefail
+
+# Helper startup script for the client.  This script will be called as the
+# entrypoint by the Docker Compose file and do the following:
+#
+# 1. Create an alias "minio" with the root/admin credentials (password
+#    comes from `/run/secrets/minio-root-password`).
+# 2. Ensure that the user "varfish" exists.  Otherwise, create it with
+#    the password from `/run/secrets/minio-varfish-password`)
+# 3. Create the "varfish-server" bucket and give "varfish" user access.
+# 4. Finally, call "sleep infinity".
+#
+# Root users on the host machine can then attach to this container as
+# follows and use the "mc" command to actually configure things, such
+# as creating users and buckets for external usage.
+#
+# ```
+# $ docker exec -it minio-client /bin/sh
+# ```
+
+# Path to this script.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Auto-cleanedup TMPDIR.
+export TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT ERR
+
+# Name of the user to create.
+S3_USER=varfish
+# Name of the bucket to create.
+S3_BUCKET=varfish-server
+
+# 1. Create the alias.
+mc alias set minio http://minio:9000 minioadmin $(cat /run/secrets/minio-root-password)
+
+# 2. Ensure that the user "varfish" exists.
+users=$(mc admin user list minio | egrep '^enabled\s+varfish' || true)
+if [ "$users" == "" ]; then
+    >&2 echo "Creating user '$S3_USER'..."
+    mc admin user add minio $S3_USER $(cat /run/secrets/minio-varfish-password)
+else
+    >&2 echo "User '$S3_USER' already exists"
+fi
+
+# 3. Create the "varfish-server" bucket and give "varfish" user access.
+buckets=$(mc ls minio | egrep "$S3_BUCKET/\$" || true)
+if [ "$buckets" == "" ]; then
+    >&2 echo "Creating bucket '$S3_BUCKET'..."
+    mc mb minio/$S3_BUCKET
+
+    >&2 echo "Create policy file that provides access for '$S3_USER' to '$S3_BUCKET'..."
+    sed -e "s/__BUCKET__/$S3_BUCKET/g" $SCRIPT_DIR/bucket-user-policy.json.tpl \
+    > $TMPDIR/$S3_USER-bucket-policy.json
+
+    >&2 echo "Import policy..."
+    mc admin policy create minio $S3_USER-bucket-policy $TMPDIR/$S3_USER-bucket-policy.json
+
+    >&2 echo "Attach policy to user..."
+    mc admin policy attach minio $S3_USER-bucket-policy --user $S3_USER
+else
+    >&2 echo "Bucket '$S3_BUCKET' already exists"
+fi
+
+# 4. Finally, call "sleep infinity".
+sleep infinity


### PR DESCRIPTION
On startup, a proper "varfish" user is created and the documentation contains instructions on how to create new users on the command line for root users.